### PR TITLE
add default injections to prevent warning when using with vue@^2.5.x

### DIFF
--- a/src/styled.js
+++ b/src/styled.js
@@ -9,7 +9,14 @@ function createComponent(tag, stylesArray) {
       tag,
       styles: stylesArray
     },
-    inject: ['theme', 'styletron'],
+    inject: {
+      theme: {
+        default: null
+      },
+      styletron: {
+        default: null
+      }
+    },
     render(h, ctx) {
       const resolvedStyle = {}
 


### PR DESCRIPTION
This will introduce a breaking change since this syntax is only available for vue@^2.5.x
(fix #4 )